### PR TITLE
VPC Peering (same account)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ provider "aws" {
 resource "aws_vpc_peering_connection" "request" {
   provider = "aws.source"
 
-  auto_accept   = "false"
+  auto_accept   = "${var.vpc_source["account_id"] != var.vpc_dest["account_id"] ? false : true}"
   peer_owner_id = "${var.vpc_dest["account_id"]}"
   peer_vpc_id   = "${var.vpc_dest["vpc_id"]}"
   vpc_id        = "${var.vpc_source["vpc_id"]}"
@@ -26,6 +26,7 @@ resource "aws_vpc_peering_connection" "request" {
 
 ## Accept the VPC connection on the other end
 resource "aws_vpc_peering_connection_accepter" "accept" {
+  count    = "${var.vpc_source["account_id"] != var.vpc_dest["account_id"] ? 1 : 0}"
   provider = "aws.dest"
 
   auto_accept               = true


### PR DESCRIPTION
The current implementation assumes different aws account, this makes that optional depending on the account id